### PR TITLE
Typo fix for 04.5-interpretable-rules.Rmd

### DIFF
--- a/manuscript/04.5-interpretable-rules.Rmd
+++ b/manuscript/04.5-interpretable-rules.Rmd
@@ -425,7 +425,7 @@ Actually the Apriori algorithm consists of two parts, where the first part finds
 For the BRL algorithm, we are only interested in the frequent patterns that are generated in the first part of Apriori.
 
 In the first step, the Apriori algorithm starts with all feature values that have a support greater than the minimum support defined by the user. 
-If the user says that the minimum support should be 10% and only 5% of the houses have $size=big$, we would remove that feature value and keep only $size=medium$ and $size=big$ as patterns. 
+If the user says that the minimum support should be 10% and only 5% of the houses have $size=big$, we would remove that feature value and keep only $size=medium$ and $size=small$ as patterns. 
 This does not mean that the houses are removed from the data, it just means that $\text{size=big}$ is not returned as frequent pattern.
 Based on frequent patterns with a single feature value, the Apriori algorithm iteratively tries to find combinations of feature values of increasingly higher order.
 Patterns are constructed by combining $feature=value$ statements with a logical AND, e.g. $\text{size=medium}\land\text{location=bad}$.


### PR DESCRIPTION
Hi, this is under 5.4.3 Bayesian rule lists: Pre-mining of frequent patterns

Original text reads:
"If the user says that the minimum support should be 10% and only 5% of the houses have $size=big$, we would remove that feature value and keep only $size=medium$ and **$size=big$** as patterns." 

Since the example removed "size=big", then the features to be kept should only be "size=medium" and **"size=small"**.
Hope this helps.