### PR TITLE
Change Lipton year

### DIFF
--- a/manuscript/02-interpretability.Rmd
+++ b/manuscript/02-interpretability.Rmd
@@ -435,7 +435,7 @@ Now that we know what an explanation is, the question arises, what a good explan
 
 Miller (2017) summarises what a 'good' explanation is, which this Chapter replicates in condensed form and with concrete suggestions for machine learning applications.
 
-**Explanations are contrastive** (Lipton 2016):
+**Explanations are contrastive** (Lipton 1990):
 Humans usually don't ask why a certain prediction was made, but rather why this prediction was made instead of another prediction.
 We tend to think in counterfactual cases, i.e. "How would the prediction have looked like, if input X were different?".
 For a house value prediction, a person might be interested in why the predicted price was high compared to the lower price she expected.


### PR DESCRIPTION
I noticed the Lipton date was wrong:
P. Lipton, Contrastive explanation, Royal Institute of Philosophy Supplement 27 (1990) 247–266.

Instead, the Lipton 1996 interpretability article was cited.  