### PR TITLE
Summation index typo in Cook's distance.

### DIFF
--- a/manuscript/06.5-example-based-influence-fct.Rmd
+++ b/manuscript/06.5-example-based-influence-fct.Rmd
@@ -141,7 +141,7 @@ DFBETA works only for models with weight parameters, such as logistic regression
 Cook's distance was invented for linear regression models and approximations for generalized linear regression models exist.
 Cook's distance for a training instance is defined as the (scaled) sum of the squared differences in the predicted outcome when the i-th instance is removed from the model training.
 
-$$D_i=\frac{\sum_{i=1}^n(\hat{y}_j-\hat{y}_{j}^{(-i)})^2}{p\cdot{}MSE}$$
+$$D_i=\frac{\sum_{j=1}^n(\hat{y}_j-\hat{y}_{j}^{(-i)})^2}{p\cdot{}MSE}$$
 
 where the numerator is the squared difference between prediction of the model with and without the i-th instance, summed over the dataset.
 The denominator is the number of features p times the mean squared error.


### PR DESCRIPTION
The sum over i would make the distance independant of i, which doesn't make any sense. I assume the sum is over j, which fit other internet sources.