### PR TITLE
Prototypes and Criticisms: Witness function: Explanations and plot do not match the definition of the witness function

### DIFF
--- a/manuscript/06.3-example-based-proto.Rmd
+++ b/manuscript/06.3-example-based-proto.Rmd
@@ -183,13 +183,13 @@ $$witness(x)=\frac{1}{n}\sum_{i=1}^nk(x,x_i)-\frac{1}{m}\sum_{j=1}^mk(x,z_j)$$
 
 For two datasets (with the same features), the witness function gives you the means of evaluating in which empirical distribution the point x fits better.
 To find criticisms, we look for extreme values of the witness function in both negative and positive directions.
-The first term in the witness function is the average proximity between point x and the prototypes, and, respectively, the second term is the average proximity between point x and the data.
+The first term in the witness function is the average proximity between point x and the data, and, respectively, the second term is the average proximity between point x and the prototypes.
 If the witness function for a point x is close to zero, the density function of the data and the prototypes are close together, which means that the distribution of prototypes resembles the distribution of the data at point x.
-A positive witness function at point x means that the prototype distribution overestimates the data distribution (for example if we select a prototype but there are only few data points nearby);
-a negative witness function at point x means that the prototype distribution underestimates the data distribution (for example if there are many data points around x but we have not selected any prototypes nearby).
+A negative witness function at point x means that the prototype distribution overestimates the data distribution (for example if we select a prototype but there are only few data points nearby);
+a positive witness function at point x means that the prototype distribution underestimates the data distribution (for example if there are many data points around x but we have not selected any prototypes nearby).
 
 To give you more intuition, let us reuse the prototypes from the plot beforehand with the lowest MMD2 and display the witness function for a few manually selected points.
-The labels in the following plot show the value of the witness function for various points marked as squares.
+The labels in the following plot show the value of the witness function for various points marked as triangles.
 Only the point in the middle has a high absolute value and is therefore a good candidate for a criticism.
 
 
@@ -202,7 +202,7 @@ witness = function(x, dist1, dist2, sigma = 1) {
 
 w.points.indices = c(125, 2, 60, 19, 100)
 wit.points = dt[w.points.indices,]
-wit.points$witness = apply(wit.points, 1, function(x) round(witness(x[c("x1", "x2")], pt2, dt, sigma = 1), 3))
+wit.points$witness = apply(wit.points, 1, function(x) round(witness(x[c("x1", "x2")], dt, pt2, sigma = 1), 3))
 
 p + geom_point(data = pt2, color = "red") + 
   geom_density_2d(data = pt2, color = "red") + 


### PR DESCRIPTION
Hi,

I think you mixed up the terms of the witness function.
The definition of the witness function is correct (according to https://papers.nips.cc/paper/6300-examples-are-not-enough-learn-to-criticize-criticism-for-interpretability.pdf). However, the first term is the average proximity between point x and the data, and, the second term is the average proximity between point x and the prototypes - you mixed them up. The same holds, when you talk about a negative/positive value of the witness function and when you compute and plot the witness function for different points.

Furthermore, the markers in the plot are not squares but triangles ;)

Or am I missing smth.?

Best wishes,
André