### PR TITLE
Fixed typo in RBF kernel equation

### DIFF
--- a/manuscript/06.3-example-based-proto.Rmd
+++ b/manuscript/06.3-example-based-proto.Rmd
@@ -162,7 +162,7 @@ gridExtra::grid.arrange(p, p1, p2, p3, ncol = 2)
 
 A choice for the kernel is the radial basis function kernel:
 
-$$k(x,x^\prime)=exp\left(\gamma||x-x^\prime||^2\right)$$
+$$k(x,x^\prime)=exp\left(-\gamma||x-x^\prime||^2\right)$$
 
 where ||x-x'||^2^ is the Euclidean distance between two points and $\gamma$ is a scaling parameter. 
 The value of the kernel decreases with the distance between the two points and ranges between zero and one:


### PR DESCRIPTION
Correct according to [Wikipedia](https://en.wikipedia.org/wiki/Radial_basis_function_kernel) has a $-\gamma$ within the parentheses.

(Section is 6.3.1)