### PR TITLE
fix markdown link to Weka Rules package

### DIFF
--- a/manuscript/04.6-interpretable-rules.Rmd
+++ b/manuscript/04.6-interpretable-rules.Rmd
@@ -680,7 +680,7 @@ In decision trees, they are implicitly categorized by splitting them.
 
 
 OneR is implemented in the [R package OneR](https://cran.r-project.org/web/packages/OneR/), which was used for the examples in this book. 
-OneR is also implemented in the [Weka machine learning library]((https://www.eecs.yorku.ca/tdb/_doc.php/userg/sw/weka/doc/weka/classifiers/rules/package-summary.html)) and as such available in Java, R and Python.
+OneR is also implemented in the [Weka machine learning library](https://www.eecs.yorku.ca/tdb/_doc.php/userg/sw/weka/doc/weka/classifiers/rules/package-summary.html) and as such available in Java, R and Python.
 RIPPER is also implemented in Weka. For the examples, I used the R implementation of JRIP in the [RWeka package](https://cran.r-project.org/web/packages/RWeka/index.html). 
 SBRL is available as [R package](https://cran.r-project.org/web/packages/sbrl/index.html) (which I used for the examples), in [Python](https://github.com/datascienceinc/Skater) or as [C implementation](https://github.com/Hongyuy/sbrlmod).
 


### PR DESCRIPTION
This PR resolves a problem with link markdown.

In Section 4.5.6, [Software And Alternatives](https://christophm.github.io/interpretable-ml-book/rules.html#software-and-alternatives), for the section on Decision Rules, the link to Weka is:

```
https://christophm.github.io/interpretable-ml-book/(https://www.eecs.yorku.ca/tdb/_doc.php/userg/sw/weka/doc/weka/classifiers/rules/package-summary.html)
```

...as shown here:

<img width="1156" alt="Screenshot 2020-03-24 at 12 01 14" src="https://user-images.githubusercontent.com/102661/77423518-47dff300-6dc7-11ea-93dd-0e371b96cda8.png">
