### PR TITLE
update link for youtube spam dataset

### DIFF
--- a/manuscript/03-datasets.Rmd
+++ b/manuscript/03-datasets.Rmd
@@ -46,7 +46,7 @@ You can find the processing R-script in the book's [Github repository](https://g
 
 ## YouTube Spam Comments (Text Classification) {#spam-data}
 As an example for text classification we work with 1956 comments from 5 different YouTube videos.
-Thankfully, the authors who used this dataset in an article on spam classification made the data  [freely available](http://dcomp.sor.ufscar.br/talmeida/youtubespamcollection/) (Alberto, Lochter, and Almeida (2015)[^Alberto]).
+Thankfully, the authors who used this dataset in an article on spam classification made the data  [freely available](https://archive.ics.uci.edu/ml/datasets/YouTube+Spam+Collection) (Alberto, Lochter, and Almeida (2015)[^Alberto]).
 
 The comments were collected via the YouTube API from five of the ten most viewed videos on YouTube in the first half of 2015. 
 All 5 are music videos.


### PR DESCRIPTION
The link for the youtube spam dataset is broken.  I updated the link to point to the dataset located on the UCI Repository 