### PR TITLE
typo: extend -> extent

### DIFF
--- a/manuscript/05.5-agnostic-interaction.Rmd
+++ b/manuscript/05.5-agnostic-interaction.Rmd
@@ -57,8 +57,8 @@ This measurement is called H-statistic, introduced by Friedman and Popescu (2008
 ### Theory: Friedman's H-statistic
 
 We are going to deal with two cases:
-First, a two-way interaction measure that tells us whether and to what extend two features in the model interact with each other;
-second, a total interaction measure that tells us whether and to what extend a feature interacts in the model with all the other features.
+First, a two-way interaction measure that tells us whether and to what extent two features in the model interact with each other;
+second, a total interaction measure that tells us whether and to what extent a feature interacts in the model with all the other features.
 In theory, arbitrary interactions between any number of features can be measured, but these two are the most interesting cases.
 
 


### PR DESCRIPTION
Minor typo in the Feature Interaction chapter: `to what extend` should be `to what extent`