### PR TITLE
Naive bayes correction suggestion

### DIFF
--- a/manuscript/04.8-interpretable-other.Rmd
+++ b/manuscript/04.8-interpretable-other.Rmd
@@ -12,7 +12,7 @@ The book teases only the Naive Bayes classifier and k-nearest neighbors in this 
 
 The Naive Bayes classifier uses the Bayes' theorem of conditional probabilities.
 For each feature, it calculates the probability for a class depending on the value of the feature.
-The Naive Bayes classifier calculates the class probabilities for each feature independently, which is equivalent to a strong (= naive) assumption of independence of the features.
+The Naive Bayes classifier calculates the class probabilities for each feature independently, which is equivalent to a strong (= naive) assumption of conditional independence of the features.
 Naive Bayes is a conditional probability model and models the probability of a class $C_k$ as follows:
 
 $$P(C_k|x)=\frac{1}{Z}P(C_k)\prod_{i=1}^n{}P(x_i|C_k)$$


### PR DESCRIPTION
Replace "assumption of independence" with "conditional independence". Alternatively, this can be formulated as: "... assumption of independence of the features given (or conditioned on) the class.