### PR TITLE
fixed rounding

### DIFF
--- a/manuscript/04.3-interpretable-logistic.Rmd
+++ b/manuscript/04.3-interpretable-logistic.Rmd
@@ -196,7 +196,7 @@ mod = glm(Biopsy ~ Hormonal.Contraceptives + Smokes + Num.of.pregnancies + STDs.
   data = cervical, family = binomial())
 # Print table of coef, exp(coef), std, p-value
 coef.table = summary(mod)$coefficients[,c('Estimate', 'Std. Error')]
-coef.table = cbind(coef.table, 'Odds ratio' = as.vector(exp(coef.table[, c('Estimate')])))
+coef.table = cbind(coef.table, 'Odds ratio' = as.vector(exp(round(coef.table[, c('Estimate')], 2))))
 # Interpret one numerical and one factor
 rownames(coef.table) = neat_cervical_names
 colnames(coef.table)[1] = 'Weight'


### PR DESCRIPTION
Hi Christoph, 
first of all thanks for the great book. 

However, there are some minor rounding errors on page 77 of the book, which are due to the fact that the `exp` is taken of the "exact" values while both the exact values and the exp values are rounded and then printed with `kable`. This especially catches one's eye with `0.82` whose exp rounded is `2.27` and not `2.26`.