### PR TITLE
Update 04.6-interpretable-rules.Rmd

### DIFF
--- a/manuscript/04.6-interpretable-rules.Rmd
+++ b/manuscript/04.6-interpretable-rules.Rmd
@@ -165,7 +165,7 @@ The predicted value of houses in good locations is `high` and again we make two 
 The error we make by using the location feature is 4/10, for the size feature it is 3/10  and for the pet feature it is 4/10 . 
 The size feature produces the rules with the lowest error and will be used for the final OneR model:
 
-IF `size=small` THEN  `value=small`  
+IF `size=small` THEN  `value=low`  
 IF `size=medium` THEN  `value=medium`  
 IF `size=big` THEN  `value=high`
 


### PR DESCRIPTION
Correct typo: `value` is one of `{low, medium, high}`