### PR TITLE
Update 04.6-interpretable-rules.Rmd: clearer phrasing in Apriori description

### DIFF
--- a/manuscript/04.6-interpretable-rules.Rmd
+++ b/manuscript/04.6-interpretable-rules.Rmd
@@ -440,7 +440,7 @@ Based on frequent patterns with a single feature value, the Apriori algorithm it
 Patterns are constructed by combining `feature=value` statements with a logical AND, e.g. `size=medium AND location=bad`.
 Generated patterns with a support below the minimum support are removed.
 In the end we have all the frequent patterns.
-Any subset of a frequent pattern is frequent again, which is called the Apriori property. 
+Any subset of a frequent pattern's clauses is frequent again, which is called the Apriori property. 
 It makes sense intuitively: 
 By removing a condition from a pattern, the reduced pattern can only cover more or the same number of data points, but not less. 
 For example, if 20% of the houses are `size=medium and location=good`, then the support of houses that are only `size=medium` is 20% or greater.


### PR DESCRIPTION
This was confusing as phrased: I took it to mean that a subset **of the instances covered** by a frequent pattern are guaranteed to be frequent themselves, which doesn't stand up.

Suggesting this re-phrase to make explicit that we're talking about diluting the selective power of the pattern, rather than selecting a subset of the instances.