### PR TITLE
Monte-Carlo Shapley algorithm

### DIFF
--- a/manuscript/05.9-agnostic-shapley.Rmd
+++ b/manuscript/05.9-agnostic-shapley.Rmd
@@ -318,12 +318,11 @@ Each of these M new instances is a kind of "Frankenstein Monster" assembled from
 - Required: Number of iterations M, instance of interest x, feature index j, data matrix X, and machine learning model f
   - For all m = 1,...,M:
     - Draw random instance z from the data matrix X
-    - Choose a random permutation o of the feature values
-    - Order instance x: $x_o=(x_{(1)},\ldots,x_{(j)},\ldots,x_{(p)})$
-    - Order instance z: $z_o=(z_{(1)},\ldots,z_{(j)},\ldots,z_{(p)})$
+    - Choose a random permutation $o$ of the feature values. With $o(i)$ the new index for feature $i$
+    - Define $y$: $y_{(i)} = x_{(i)}$ if $o(i) < j$ or $y_{(i)} = z_{(i)}$ if $o(i) > j$
     - Construct two new instances
-        - With feature j: $x_{+j}=(x_{(1)},\ldots,x_{(j-1)},x_{(j)},z_{(j+1)},\ldots,z_{(p)})$
-        - Without feature j: $x_{-j}=(x_{(1)},\ldots,x_{(j-1)},z_{(j)},z_{(j+1)},\ldots,z_{(p)})$
+        - With feature j: $x_{+j}=(y_{(1)},\ldots,y_{(j-1)},x_{(j)},y_{(j+1)},\ldots,y_{(p)})$
+        - Without feature j: $x_{-j}=(y_{(1)},\ldots,y_{(j-1)},z_{(j)},y_{(j+1)},\ldots,y_{(p)})$
     - Compute marginal contribution: $\phi_j^{m}=\hat{f}(x_{+j})-\hat{f}(x_{-j})$
 - Compute Shapley value as the average: $\phi_j(x)=\frac{1}{M}\sum_{m=1}^M\phi_j^{m}$
 


### PR DESCRIPTION
Addresses [this issue](https://github.com/christophM/interpretable-ml-book/issues/202)

As described in the issue, I think that the description of the algorithm:

> For each iteration, a random instance z is selected from the data and a random order of the features is generated. Two new instances are created by combining values from the instance of interest x and the sample z. The instance x+j is the instance of interest, but all values in the order before feature j are replaced by feature values from the sample z

was not represented correctly by the pseudocode. there was not a proper distinction between the feature vector ordered with the permutation `o` and the true original ordering. 