### PR TITLE
Corrected Quantile Definition

### DIFF
--- a/manuscript/07.1-feature-visualization.Rmd
+++ b/manuscript/07.1-feature-visualization.Rmd
@@ -205,7 +205,7 @@ At this point the concept labels are not yet involved.
         - Forward propagate image x to the target layer containing channel k.
         - Extract the pixel activations of convolutional channel k: $A_k(x)$
     - Calculate distribution of pixel activations $\alpha_k$ over all images
-    - Determine the 0.005-quantile level $T_k$ of activations $\alpha_k$. This means 0.5% of all activations of channel k for image x are greater than $T_k$.
+    - Determine the 0.995-quantile level $T_k$ of activations $\alpha_k$. This means 0.5% of all activations of channel k for image x are greater than $T_k$.
     - For each image x in the Broden dataset:
         - Scale the (possibly) lower-resolution activation map $A_k(x)$ to the resolution of image x. We call the result $S_k(x)$.
         - Binarize the activation map: A pixel is either on or off, depending on whether it exceeds the activation threshold $T_k$. The new mask is $M_k(x)=S_k(x)\geq{}T_k(x)$.


### PR DESCRIPTION
Hey, just a minor issue: 

In section 7.1.2.1, Step 2 in the algorithm you write "Determine the 0.005-quantile level T of activations. This means 0.5% of all activations of channel k for image x are greater than T.". This should be the 0.995 quantile, since a quantile always defines how many values are smaller than or equal to it (see https://en.wikipedia.org/wiki/Quantile#Quantiles_of_a_population ). Note that Bau and Zhou also used this correct definition in their paper, but wrote it kind of weird ("select the quantile so that it has 0.5% greater than it"), which I believe lead to the mistake in the book.

PS: Other than that, a great book! I already recommended it to several students.