### PR TITLE
counterfactual example header typo fixed

### DIFF
--- a/manuscript/06.1-example-based-counterfactual.Rmd
+++ b/manuscript/06.1-example-based-counterfactual.Rmd
@@ -259,7 +259,7 @@ The counterfactuals should answer how the input features need to be changed to g
 
 The following table shows the 10 best counterfactuals:
 
-|age|sex|job |amount|duration|$o_2$|$o_3$|$o_3$|$\hat{f}(x')$|
+|age|sex|job |amount|duration|$o_2$|$o_3$|$o_4$|$\hat{f}(x')$|
 |---|---|----|-------------|--------|---------------|----------|----------|----|
 |   |   |skilled   |             |-20     |0.108          |2         |0.036     |0.501|
 |   |   |skilled   |             |-24     |0.114          |2         |0.029     |0.525|


### PR DESCRIPTION
Fixing the typo in the table header. Next to last header is for the 4th objective rather than the 3rd.