### PR TITLE
fix typo in coverage definition formula of Anchor

### DIFF
--- a/manuscript/05.8.1-agnostic-Anchors.Rmd
+++ b/manuscript/05.8.1-agnostic-Anchors.Rmd
@@ -70,7 +70,7 @@ $$P(prec(A)\geq\tau)\geq{}1-\delta\quad\textrm{with}\quad{}prec(A)=\mathbb{E}_{\
 
 The previous two definitions are combined and extended by the notion of coverage. Its rationale consists of finding rules that apply to a preferably large part of the model’s input space. Coverage is formally defined as an anchors' probability of applying to its neighbors, i.e., its perturbation space: 
 
-$$cov(A)=\mathbb{E}_{\mathcal{D}_{(z)}[A(z)]}$$ 
+$$cov(A)=\mathbb{E}_{\mathcal{D}_{(z)}}[A(z)]$$ 
 
 Including this element leads to anchors' final definition taking into account the maximization of coverage:
 


### PR DESCRIPTION
While reading very interesting book, I found a typo in the section of "Finding Anchors " (https://christophm.github.io/interpretable-ml-book/anchors.html#finding-anchors).

In coverage definition formula, "[A(z)]" becomes subscript, but it should be not.

I fixed this typo.