### PR TITLE
Small typo in Vanilla Gradient Example

### DIFF
--- a/manuscript/07.2-feature-attribution.Rmd
+++ b/manuscript/07.2-feature-attribution.Rmd
@@ -120,7 +120,7 @@ $$
 \end{pmatrix}
 $$
 
-Then our gradients at $X_n$ are:
+Then our gradients at $X_{(n+1)}$ are:
 
 $$
 \begin{pmatrix}


### PR DESCRIPTION
Typo in subscript of term x_n -> x_{n+1}