### PR TITLE
fixed as --> a Line 425

### DIFF
--- a/manuscript/05.8-agnostic-lime.Rmd
+++ b/manuscript/05.8-agnostic-lime.Rmd
@@ -422,7 +422,7 @@ Even if you **replace the underlying machine learning model**, you can still use
 Suppose the people looking at the explanations understand decision trees best.
 Because you use local surrogate models, you use decision trees as explanations without actually having to use a decision tree to make the predictions.
 For example, you can use a SVM.
-And if it turns out that an xgboost model works better, you can replace the SVM and still use as decision tree to explain the predictions.
+And if it turns out that an xgboost model works better, you can replace the SVM and still use a decision tree to explain the predictions.
 
 Local surrogate models benefit from the literature and experience of training and interpreting interpretable models.
 


### PR DESCRIPTION
I fixed a small typo, changed "as" to "a" on Line 425 of the 9.2 LIME page.