### PR TITLE
Fix typos in `05.9-agnostic-shapley`

### DIFF
--- a/manuscript/05.9-agnostic-shapley.Rmd
+++ b/manuscript/05.9-agnostic-shapley.Rmd
@@ -309,10 +309,10 @@ $$\hat{\phi}_{j}=\frac{1}{M}\sum_{m=1}^M\left(\hat{f}(x^{m}_{+j})-\hat{f}(x^{m}_
 
 where $\hat{f}(x^{m}_{+j})$ is the prediction for x, but with a random number of feature values replaced by feature values from a random data point z, except for the respective value of feature j.
 The x-vector $x^{m}_{-j}$ is almost identical to $x^{m}_{+j}$, but the value $x_j^{m}$ is also taken from the sampled z.
-Each of these M new instances is a kind of "Frankenstein Monster" assembled from two instances.
+Each of these M new instances is a kind of "Frankenstein's Monster" assembled from two instances.
 Note that in the following algorithm, the order of features is not actually changed -- each feature remains at the same vector position when passed to the predict function.
 The order is only used as a "trick" here:
-By giving the features features a new order, we get a random mechanism that helps us put together the "Frankenstein Monster".
+By giving the features a new order, we get a random mechanism that helps us put together the "Frankenstein's Monster".
 For features that appear left of the feature $x_j$, we take the values from the original observations, and for the features on the right, we take the values from a random instance.
 
 **Approximate Shapley estimation for single feature value**:


### PR DESCRIPTION
Thanks for the great book!

Here's a fix for some smaller typos in the section about estimating Shapley values.