### PR TITLE
Possibly fix newlines in plain text

### DIFF
--- a/manuscript/01.2-short-stories.Rmd
+++ b/manuscript/01.2-short-stories.Rmd
@@ -12,6 +12,7 @@ The format is inspired by Jack Clark's Tech Tales in his [Import AI Newsletter](
 If you like this kind of stories or if you are interested in AI, I recommend that you sign up.
 
 ### Lightning Never Strikes Twice {-}
+
 **2030: A medical lab in Switzerland**
 
 ```{r hospital, echo = FALSE, fig.cap = "", fig.align = "center", out.width = "\\textwidth" }


### PR DESCRIPTION
The section about the lightning and the pain killers at https://christophm.github.io/interpretable-ml-book/storytime.html#lightning-never-strikes-twice does not ignore the newlines. My guess is that this is a Pandoc bug caused by the fact that for bold text newlines shouldn't be ignored. Adding an empty line might solve it since the next section does have an empty line between the subsection and the bold font text. I haven't tested this locally 