### PR TITLE
Correct the definition of boxplot whiskers and outliers

### DIFF
--- a/manuscript/04.2-interpretable-linear.Rmd
+++ b/manuscript/04.2-interpretable-linear.Rmd
@@ -235,11 +235,9 @@ Start by calculating the effects, which is the weight per feature times the feat
 
 $$\text{effect}_{j}^{(i)}=w_{j}x_{j}^{(i)}$$
 
-The effects can be visualized with boxplots.
-A box in a boxplot contains the effect range for half of your data (25% to 75% effect quantiles).
-The vertical line in the box is the median effect, i.e. 50% of the instances have a lower and the other half a higher effect on the prediction.
-The horizontal lines extend to $\pm1.5\text{IQR}/\sqrt{n}$, with IQR being the inter quartile range (75% quantile minus 25% quantile).
-The dots are outliers.
+The effects can be visualized with [boxplots](https://ggplot2.tidyverse.org/reference/geom_boxplot.html). The box in a boxplot contains the effect range for half of the data (25% to 75% effect quantiles).
+The vertical line in the box is the median effect, i.e. 50% of the instances have a lower and the other half a higher effect on the prediction. The dots are outliers, defined as points that are more than 1.5 * IQR (interquartile range, that is, the difference between the first and third quartiles) above the third quartile, or less than 1.5 * IQR below the first quartile. The two horizontal lines, called the lower and upper whiskers, connect the points below the first quartile and above the third quartile that are not outliers. If there are no outliers the whiskers will extend to the minimum and maximum values.
+
 The categorical feature effects can be summarized in a single boxplot, compared to the weight plot, where each category has its own row.
 
 ```{r linear-effects, fig.cap="The feature effect plot shows the distribution of effects (= feature value times feature weight) across the data per feature."}

--- a/manuscript/04.2-interpretable-linear.Rmd
+++ b/manuscript/04.2-interpretable-linear.Rmd
@@ -235,8 +235,12 @@ Start by calculating the effects, which is the weight per feature times the feat
 
 $$\text{effect}_{j}^{(i)}=w_{j}x_{j}^{(i)}$$
 
-The effects can be visualized with [boxplots](https://ggplot2.tidyverse.org/reference/geom_boxplot.html). The box in a boxplot contains the effect range for half of the data (25% to 75% effect quantiles).
-The vertical line in the box is the median effect, i.e. 50% of the instances have a lower and the other half a higher effect on the prediction. The dots are outliers, defined as points that are more than 1.5 * IQR (interquartile range, that is, the difference between the first and third quartiles) above the third quartile, or less than 1.5 * IQR below the first quartile. The two horizontal lines, called the lower and upper whiskers, connect the points below the first quartile and above the third quartile that are not outliers. If there are no outliers the whiskers will extend to the minimum and maximum values.
+The effects can be visualized with [boxplots](https://ggplot2.tidyverse.org/reference/geom_boxplot.html).
+The box in a boxplot contains the effect range for half of the data (25% to 75% effect quantiles).
+The vertical line in the box is the median effect, i.e. 50% of the instances have a lower and the other half a higher effect on the prediction.
+The dots are outliers, defined as points that are more than 1.5 * IQR (interquartile range, that is, the difference between the first and third quartiles) above the third quartile, or less than 1.5 * IQR below the first quartile.
+The two horizontal lines, called the lower and upper whiskers, connect the points below the first quartile and above the third quartile that are not outliers.
+If there are no outliers the whiskers will extend to the minimum and maximum values.
 
 The categorical feature effects can be summarized in a single boxplot, compared to the weight plot, where each category has its own row.
 


### PR DESCRIPTION
The original formulation included dividing the IQR by sqrt(n) which is not how whisker lengths are calculated. (It's part of the formula for notched boxplots.)