### PR TITLE
Fix typo in title (Decompositon -> Decomposition)

### DIFF
--- a/manuscript/05-agnostic-decomposition.Rmd
+++ b/manuscript/05-agnostic-decomposition.Rmd
@@ -11,7 +11,7 @@ set.seed(42)
 - Research paper that cite  Generalized functional anova diagnostics for high-dimensional functions of dependent variables.
 -->
 
-## Functional Decompositon {#decomposition}
+## Functional Decomposition {#decomposition}
 
 A supervised machine learning model can be viewed as a function that takes a high-dimensional feature vector as input and produces a prediction or classification score as output.
 Functional decomposition is an interpretation technique that deconstructs the high-dimensional function and expresses it as a sum of individual feature effects and interaction effects that can be visualized.


### PR DESCRIPTION
Hi, I found a small typo in the title of chapter 8.4. It should be "Functional Decomposition" instead of "Functional Decompositon" (missing 'i').