### PR TITLE
Fixed typo

### DIFF
--- a/manuscript/05.9b-agnostic-shap.Rmd
+++ b/manuscript/05.9b-agnostic-shap.Rmd
@@ -199,7 +199,7 @@ If we add an L1 penalty to the loss L, we can create sparse explanations.
 Lundberg et al. (2018)[^treeshap] proposed TreeSHAP, a variant of SHAP for tree-based machine learning models such as decision trees, random forests and gradient boosted trees.
 TreeSHAP was introduced as a fast, model-specific alternative to KernelSHAP, but it turned out that it can produce unintuitive feature attributions.
 
-TreeSHAP defines the value function using the conditional expectation $E_{X_j|X_{-j}}(\hat{f}(x)|x_j)$ instead of the marginal expectation.
+TreeSHAP defines the value function using the conditional expectation $E_{X_{-j}|X_j}(\hat{f}(x)|x_j)$ instead of the marginal expectation.
 The problem with the conditional expectation is that features that have no influence on the prediction function f can get a TreeSHAP estimate different from zero as shown by Sundararajan et al. (2019) [^cond1] and Janzing et al. (2019) [^cond2].
 The non-zero estimate can happen when the feature is correlated with another feature that actually has an influence on the prediction.
 


### PR DESCRIPTION
The expected value is taken over the features that are not in the coalition.