### PR TITLE
Correcting the cost function formula for Counterfactual examples (Dandl et al.'s method) (S#9.3.1.2)

### DIFF
--- a/manuscript/06.1-example-based-counterfactual.Rmd
+++ b/manuscript/06.1-example-based-counterfactual.Rmd
@@ -177,13 +177,13 @@ Let us now have a look on another approach overcoming these issues.
 
 Dandl et al. suggest to simultaneously minimize a four-objective loss:
 
-$$L(x,x',y',X^{obs})=\big(o_1(\hat{f}(x'),y'),o_2(x, x'),o_3(x,x'),o_4(x',X^{obs})\big) $$ 
+$$L(x,x',y',X^{obs})=\big(o_1(\hat{f}(x'),Y'),o_2(x, x'),o_3(x,x'),o_4(x',X^{obs})\big) $$ 
 
-Each of the four objectives $o_1$ to $o_4$ corresponds to one of the four criteria mentioned above.
+where $Y'$ is a set of desired outcomes. Each of the four objectives $o_1$ to $o_4$ corresponds to one of the four criteria mentioned above.
 The first objective $o_1$ reflects that the prediction of our counterfactual x' should be as close as possible to our desired prediction y'.
-We therefore want to minimize the distance between $\hat{f}(x')$ and y', here calculated by the Manhattan metric ($L_1$ norm):
+We therefore want to minimize the distance between $\hat{f}(x')$ and a set of desired outcomes Y', here calculated by the Manhattan metric ($L_1$ norm):
 
-$$o_1(\hat{f}(x'),y')=\begin{cases}0&\text{if $\hat{f}(x')\in{}y'$}\\\inf\limits_{y'\in y'}|\hat{f}(x')-y'|&\text{else}\end{cases}$$
+$$o_1(\hat{f}(x'),y')=\begin{cases}0&\text{if $\hat{f}(x')\in{}Y'$}\\\inf\limits_{y'\in Y'}|\hat{f}(x')-y'|&\text{else}\end{cases}$$
 
 The second objective $o_2$ reflects that our counterfactual should be as similar as possible to our instance $x$.
 It quantifies the distance between x' and x


### PR DESCRIPTION
While reading the book, I found that the formula for the first part of the cost function has a typo. Therefore, I consulted the [source paper](https://arxiv.org/pdf/2004.11165.pdf) and fixed it.