### PR TITLE
Update link to Elements of Statistical Learning

### DIFF
--- a/manuscript/01-introduction.Rmd
+++ b/manuscript/01-introduction.Rmd
@@ -7,7 +7,7 @@ This book explains to you how to make (supervised) machine learning models inter
 The chapters contain some mathematical formulas, but you should be able to understand the ideas behind the methods even without the formulas.
 This book is not for people trying to learn machine learning from scratch.
 If you are new to machine learning, there are a lot of books and other resources to learn the basics.
-I recommend the book "The Elements of Statistical Learning" by Hastie, Tibshirani, and Friedman (2009) [^Hastie] and [Andrew Ng's "Machine Learning" online course](https://www.coursera.org/learn/machine-learning)  on the online learning platform  coursera.com to start with machine learning.
+I recommend the book ["The Elements of Statistical Learning" by Hastie, Tibshirani, and Friedman (2009)](https://hastie.su.domains/ElemStatLearn/) [^Hastie] and [Andrew Ng's "Machine Learning" online course](https://www.coursera.org/learn/machine-learning)  on the online learning platform  coursera.com to start with machine learning.
 Both the book and the course are available free of charge!
 
 New methods for the interpretation of machine learning models are published at breakneck speed.
@@ -32,4 +32,4 @@ You can either read the book from beginning to end or jump directly to the metho
 
 I hope you will enjoy the read!
 
-[^Hastie]: Friedman, Jerome, Trevor Hastie, and Robert Tibshirani. "The elements of statistical learning". www.web.stanford.edu/~hastie/ElemStatLearn/  (2009).
+[^Hastie]: Friedman, Jerome, Trevor Hastie, and Robert Tibshirani. "The elements of statistical learning". hastie.su.domains/ElemStatLearn  (2009).


### PR DESCRIPTION
The Elements of Statiscal Learning has the following comment on the homepage:

```
Please note: as of 2022 the references in the book to www-stat.stanford.edu/ElemStatLearn should be changed to hastie.su.domains/ElemStatLearn
```

I've just updated the links to reflect this :)