### PR TITLE
added: regional effect plots and effector

### DIFF
--- a/manuscript/ale.qmd
+++ b/manuscript/ale.qmd
@@ -630,7 +630,7 @@ In this case, reducing the number of intervals makes the estimates more stable, 
 There's **no perfect solution for setting the number of intervals**.
 If the number is too small, the ALE plots might not be very accurate.
 If the number is too high, the curve can become shaky.
-To compromise smoothness and accuracy, Gkolemis et al. (2023) [@gkolemis2023rhale] proposed an automated bin-splitting approach that progressively enlarges bins (for more stable estimates) as long as the local effects within them remain relatively constant (for preserving the model's true complexity).  
+To compromise smoothness and accuracy, @gkolemis2023rhale proposed an automated bin-splitting approach that progressively enlarges bins (for more stable estimates) as long as the local effects within them remain relatively constant (for preserving the model's true complexity).  
 
 Unlike PDPs, **ALE plots are not accompanied by ICE curves**.
 For PDPs, ICE curves are great because they can reveal heterogeneity in the feature effect, which means that the effect of a feature looks different for subsets of the data.

--- a/manuscript/ale.qmd
+++ b/manuscript/ale.qmd
@@ -630,6 +630,7 @@ In this case, reducing the number of intervals makes the estimates more stable, 
 There's **no perfect solution for setting the number of intervals**.
 If the number is too small, the ALE plots might not be very accurate.
 If the number is too high, the curve can become shaky.
+To compromise smoothness and accuracy, Gkolemis et al. (2023) [@gkolemis2023rhale] proposed an automated bin-splitting approach that progressively enlarges bins (for more stable estimates) as long as the local effects within them remain relatively constant (for preserving the model's true complexity).  
 
 Unlike PDPs, **ALE plots are not accompanied by ICE curves**.
 For PDPs, ICE curves are great because they can reveal heterogeneity in the feature effect, which means that the effect of a feature looks different for subsets of the data.
@@ -667,4 +668,4 @@ Did I mention that [partial dependence plots](#pdp) and [individual conditional 
 =)
 
 ALE plots are implemented in R in the [ALEPlot R package](https://cran.r-project.org/web/packages/ALEPlot/index.html) by the inventor himself, and once in the [iml package](https://cran.r-project.org/web/packages/iml/index.html).
-ALE also has a couple of Python implementations: [ALEPython](https://github.com/blent-ai/ALEPython), [Alibi](https://docs.seldon.io/projects/alibi/en/stable/index.html), and [PiML](https://selfexplainml.github.io/PiML-Toolbox/_build/html/index.html).
+ALE also has a couple of Python implementations: [`effector`](https://github.com/givasile/effector), [ALEPython](https://github.com/blent-ai/ALEPython), [Alibi](https://docs.seldon.io/projects/alibi/en/stable/index.html), and [PiML](https://selfexplainml.github.io/PiML-Toolbox/_build/html/index.html).

--- a/manuscript/pdp.qmd
+++ b/manuscript/pdp.qmd
@@ -332,7 +332,7 @@ You then conclude that the feature has no effect on the prediction.
 By plotting the [individual conditional expectation curves](#ice) instead of the aggregated line, we can uncover heterogeneous effects.
 However, ICE plots cannot indicate **when** the effect is positive or negative—a key aspect for interpretation.
 Suppose that the direction of the effect (positive or negative) depends on another feature—when the other feature's value is above a certain threshold, the effect is positive and vice versa.
-Regional feature effect plots [@herbinger2024decomposing], [@herbinger2022repid], [@britton2019vine], [@gkolemis2024fast] address this by partitioning data based on the conditioning feature and computing subgroup-specific PDPs. This approach clearly reveals **under which condition** the effect is positive or negative and reduces the overall heterogeneity.
+Regional feature effect plots [@herbinger2024decomposing;@herbinger2022repid;@britton2019vine;@gkolemis2024fast] address this by partitioning data based on the conditioning feature and computing subgroup-specific PDPs. This approach clearly reveals **under which condition** the effect is positive or negative and reduces the overall heterogeneity.
 
 ## Software and alternatives
 

--- a/manuscript/pdp.qmd
+++ b/manuscript/pdp.qmd
@@ -330,14 +330,17 @@ Suppose that for a feature half your data points have a positive association wit
 The PD curve could be a horizontal line since the effects of both halves of the dataset could cancel each other out.
 You then conclude that the feature has no effect on the prediction.
 By plotting the [individual conditional expectation curves](#ice) instead of the aggregated line, we can uncover heterogeneous effects.
-
+However, ICE plots cannot indicate **when** the effect is positive or negative—a key aspect for interpretation.
+Suppose that the direction of the effect (positive or negative) depends on another feature—when the other feature's value is above a certain threshold, the effect is positive and vice versa.
+Regional feature effect plots [@herbinger2024decomposing], [@herbinger2022repid], [@britton2019vine], [@gkolemis2024fast] address this by partitioning data based on the conditioning feature and computing subgroup-specific PDPs. This approach clearly reveals **under which condition** the effect is positive or negative and reduces the overall heterogeneity.
 
 ## Software and alternatives
 
 There are a number of R packages that implement PDPs.
 I used the `iml` package for the examples, but there is also `pdp` and `DALEX`.
-In Python, partial dependence plots are built into `scikit-learn`, and you can use `PDPBox`.
+In Python, partial dependence plots are built into `scikit-learn`, `PDPBox` and [`effector`](https://github.com/givasile/effector).
 Or you can use the [Python Interpretable Machine Learning (PiML) library](https://selfexplainml.github.io/PiML-Toolbox/_build/html/index.html).
+[`effector`](https://github.com/givasile/effector) also implements regional PDP plots.
 
 Alternatives to PDPs presented in this book are [ALE plots](#ale) and [ICE curves](#ice).
 

--- a/manuscript/references.bib
+++ b/manuscript/references.bib
@@ -1852,3 +1852,45 @@
   year={2020}
 }
 
+@inproceedings{herbinger2022repid,
+  title={REPID: regional effect plots with implicit interaction detection},
+  author={Herbinger, Julia and Bischl, Bernd and Casalicchio, Giuseppe},
+  booktitle={International conference on artificial intelligence and statistics},
+  pages={10209--10233},
+  year={2022},
+  organization={PMLR}
+}
+
+@article{herbinger2024decomposing,
+  title={Decomposing global feature effects based on feature interactions},
+  author={Herbinger, Julia and Wright, Marvin N and Nagler, Thomas and Bischl, Bernd and Casalicchio, Giuseppe},
+  journal={Journal of Machine Learning Research},
+  volume={25},
+  number={381},
+  pages={1--65},
+  year={2024}
+}
+
+@article{britton2019vine,
+  title={Vine: Visualizing statistical interactions in black box models},
+  author={Britton, Matthew},
+  journal={arXiv preprint arXiv:1904.00561},
+  year={2019}
+}
+
+@article{gkolemis2024fast,
+  title={Fast and Accurate Regional Effect Plots for Automated Tabular Data Analysis},
+  author={Gkolemis, Vasilis and Dalamagas, Theodore and Ntoutsi, Eirini and Diou, Christos},
+  journal={Proceedings of the VLDB Endowment. ISSN},
+  volume={2150},
+  pages={8097}
+}
+
+@incollection{gkolemis2023rhale,
+  title={RHALE: robust and heterogeneity-aware accumulated local effects},
+  author={Gkolemis, Vasilis and Dalamagas, Theodore and Ntoutsi, Eirini and Diou, Christos},
+  booktitle={ECAI 2023},
+  pages={859--866},
+  year={2023},
+  publisher={IOS Press}
+}


### PR DESCRIPTION
Added:

* a reference to `effector`, a python packages for global and regional effect plots 
* a paragraph for regional effect plots (and in particular regional PDPs) as a way to address increased heterogeneity
* a sentence for automatic bin splitting in ALE plots (RHALE paper)